### PR TITLE
Adjust Hack mdelay time

### DIFF
--- a/drivers/input/touchscreen/lfp100.c
+++ b/drivers/input/touchscreen/lfp100.c
@@ -1111,7 +1111,7 @@ static int lfp100_chip_probe(struct platform_device *pdev)
 //HACK HACK HACK
 			#if 	(CFG_SYS_MCLK_FREQ >= 266666666)
 				lfp100_write_reg(LFP100_DCDC1_PW, LFP100_DCDC1_PW_1P3_VOLTS);
-        		mdelay(100);// Give power time to settle to new level
+        		mdelay(200);// Give power time to settle to new level
 				printk(KERN_WARNING "%s: Clock faster than stock; LFP100 DCDC1 set to 0x%X\n",
 					__FUNCTION__, lfp100_read_reg(LFP100_DCDC1_PW));
 					


### PR DESCRIPTION
I briefly discussed this with Mac - this is a hacky delay to allow the overclock to settle down before configuring the touchscreen. I think it might need to be longer to stop the GS in particular hanging on the Leapfrog screen on startup around 50% of the time.  May need some experimenting with values to see if this has any effect.